### PR TITLE
[AC-2827] Fix trimmed playback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "videojs-offset",
-  "version": "2.1.2",
+  "name": "@prezi/videojs-offset-test",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "videojs-offset",
-  "version": "2.1.2",
+  "name": "@prezi/videojs-offset",
+  "version": "2.1.4",
   "description": "",
   "main": "dist/videojs-offset.cjs.js",
   "jsnext:main": "src/js/index.js",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -39,6 +39,33 @@ const onPlayerTimeUpdate = function() {
     }
   }
 };
+
+const isOutside = (player) => player._offsetEnd !== null && player.currentTime() + 0.001 >= player._offsetEnd - (player._offsetStart || 0);
+
+const onPause = function() {
+  if (isOutside(this)) {
+    this.trigger('loadstart');
+  }
+};
+
+const onPlay = function() {
+  if (isOutside(this)) {
+    this.currentTime(0);
+  }
+};
+
+const onCanPlay = function() {
+  if (isOutside(this)) {
+    this.trigger('ended');
+  }
+};
+
+const onCanPlayThrough = function() {
+  if (isOutside(this)) {
+    this.trigger('ended');
+  }
+};
+
 /**
  * Function to invoke when the player is ready.
  *
@@ -56,6 +83,17 @@ const onPlayerReady = (player, options) => {
   player.one('play', () => {
     player.on('timeupdate', onPlayerTimeUpdate);
   });
+
+  // add the listeners if not already added
+  player.off('pause', onPause);
+  player.off('play', onPlay);
+  player.off('canplay', onCanPlay);
+  player.off('canplaythrough', onCanPlayThrough);
+
+  player.on('pause', onPause);
+  player.on('play', onPlay);
+  player.on('canplay', onCanPlay);
+  player.on('canplaythrough', onCanPlayThrough);
 };
 
 /**


### PR DESCRIPTION
## Description
Add various listeners to check for end of trimmed video
After this it is possible to set the offset without the `restart_beginning` option set to `true`, because the play button will become restart after the trimmed video is played.